### PR TITLE
Fixed four issues

### DIFF
--- a/CSSMenu-catsPropertiesComponent.js
+++ b/CSSMenu-catsPropertiesComponent.js
@@ -9,7 +9,7 @@ define(
     
     var o = {
       template: commonPropertiesTemplate,
-      controller: ["$scope", "$element", "$timeout", function($scope, o, p) {
+      controller: ["$scope", "$element", "$timeout", "qvContextMenu", function($scope, o, p, qvContextMenu) {
         
         var catList;
         
@@ -40,13 +40,16 @@ define(
               
               newCat = catList.createItem({
                 component: components.getComponent("items"),
-                definition: $scope.definition.catDef,
+                definition: {
+					type: "items",
+					items: $scope.definition.catDef
+				},
+				type: "category",
                 data: v,
                 args: $scope.args,
                 id: v.id,
                 sortable: true,
                 index: 0,
-                type: "category",
                 templateSrc: "pp-sorting-item.ng.html",
                 title: function() {
                   return v.catName;
@@ -58,13 +61,16 @@ define(
              
               newCat = catList.createItem({
                 component: components.getComponent("items"),
-                definition: $scope.definition.catDef,
+                definition: {
+					type: "items",
+					items: $scope.definition.catDef
+				},
+				type: "category",
                 data: v,
                 args: $scope.args,
                 id: v.id,
                 sortable: true,
                 index: 0,
-                type: "category",
                 templateSrc: "pp-data-item.ng.html",
                 title: function() {
                   return v.catName;
@@ -175,7 +181,7 @@ define(
         
         var contextMenu;
         $scope.openContextMenu = function(a, b) {
-          var c = context.menu();
+          var c = qvContextMenu.menu();
           
           c.addItem({
             translation: "Common.Delete",
@@ -185,7 +191,7 @@ define(
             }
           });
           
-          contextMenu = context.show(c, {
+          contextMenu = qvContextMenu.show(c, {
             position: {
               x: a.pageX,
               y: a.pageY
@@ -210,7 +216,7 @@ define(
           hideAddClicked();
           contextMenu && contextMenu.destroy();
         });
-        
+
         catList = $scope.sortableItemLists.createList(1, {
           title: "Categories",
           tid: "categories2"

--- a/CSSMenu-sheetsPropertiesComponent.js
+++ b/CSSMenu-sheetsPropertiesComponent.js
@@ -9,7 +9,7 @@ define(
     
     var o = {
       template: commonPropertiesTemplate,
-      controller: ["$scope", "$element", "$timeout", function($scope, o, p) {
+      controller: ["$scope", "$element", "$timeout", "qvContextMenu", function($scope, o, p, qvContextMenu) {
         
         var catList = {};
         
@@ -142,13 +142,15 @@ define(
 
             var newSheet = catList[v.catId].createItem({
               component: components.getComponent("items"),
-              definition: $scope.definition.sheetDef,
+              definition: {
+				type: "sheet",
+				items: $scope.definition.sheetDef
+			  },
               data: v,
               args: $scope.args,
               id: v.id,
               sortable: true,
               index: v.order,
-              type: "sheet",
               templateSrc: "pp-sorting-item.ng.html",
               title: function() {
                 return (
@@ -210,7 +212,7 @@ define(
         
         var contextMenu;
         $scope.openContextMenu = function(a, b) {
-          var c = context.menu();
+          var c = qvContextMenu.menu();
           
           c.addItem({
             translation: "Common.Delete",
@@ -220,7 +222,7 @@ define(
             }
           });
           
-          contextMenu = context.show(c, {
+          contextMenu = qvContextMenu.show(c, {
             position: {
               x: a.pageX,
               y: a.pageY

--- a/README.md
+++ b/README.md
@@ -45,3 +45,18 @@ If you want you can set an action to be executed before navigating to a sheet.
 # Credits
 
 This extension is inspired by the swr-sheetnavigation extension of Stefan Walther
+
+# Fixes
+
+This fork fixes the following issues
+
+* Allow renaming cat name
+* Allow editing cat properties
+* contex menu on right click
+* Allow editing sheet properties
+* Context menu on right click
+
+# Known Issues
+Following minor knows issues exists
+* Firts edits works, Again you have to hit "Done" and then hit Ëdit" to do any modifications
+


### PR DESCRIPTION
Fixed four issues

1) Allow renaming cat name
2) Allow editing cat properties
3) contex menu on right click
4) Allow editing sheet properties
5) Context menu on right click

Appreciate if a tag is created for Qliksense 1.0, prior to merging these changes whish is specific to v2
Further there are still minor issues, which will be resolved soon for example, first time edit working, next time onwards we have to hit done and then edit.
